### PR TITLE
JNA: update to 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>3.4.0</version>
+      <version>3.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/jvnet/libpam/impl/BSDPasswd.java
+++ b/src/main/java/org/jvnet/libpam/impl/BSDPasswd.java
@@ -24,6 +24,9 @@
 
 package org.jvnet.libpam.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.jvnet.libpam.impl.CLibrary.passwd;
 
 /**
@@ -76,6 +79,14 @@ public class BSDPasswd extends passwd {
     @Override
     public String getPwShell() {
         return pw_shell;
+    }
+
+    @Override
+    protected List getFieldOrder() {
+        List fieldOrder = new ArrayList(super.getFieldOrder());
+        fieldOrder.addAll(Arrays.asList("pw_change", "pw_class", "pw_gecos",
+                "pw_dir", "pw_shell", "pw_expire"));
+        return fieldOrder;
     }
 
 }

--- a/src/main/java/org/jvnet/libpam/impl/CLibrary.java
+++ b/src/main/java/org/jvnet/libpam/impl/CLibrary.java
@@ -30,6 +30,8 @@ import com.sun.jna.Library;
 import com.sun.jna.Structure;
 import com.sun.jna.Memory;
 import com.sun.jna.ptr.IntByReference;
+import java.util.Arrays;
+import java.util.List;
 import org.jvnet.libpam.PAMException;
 
 /**
@@ -90,11 +92,19 @@ public interface CLibrary extends Library {
         public String getPwShell() {
             return null;
         }
+
+        protected List getFieldOrder() {
+            return Arrays.asList("pw_name", "pw_passwd", "pw_uid", "pw_gid");
+        }
     }
 
     public class group extends Structure {
         public String gr_name;
         // ... the rest of the field is not interesting for us
+
+        protected List getFieldOrder() {
+            return Arrays.asList("gr_name");
+        }
     }
 
     Pointer calloc(int count, int size);

--- a/src/main/java/org/jvnet/libpam/impl/LinuxPasswd.java
+++ b/src/main/java/org/jvnet/libpam/impl/LinuxPasswd.java
@@ -24,6 +24,9 @@
 
 package org.jvnet.libpam.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.jvnet.libpam.impl.CLibrary.passwd;
 
 /**
@@ -65,6 +68,13 @@ public class LinuxPasswd extends passwd {
     @Override
     public String getPwShell() {
         return pw_shell;
+    }
+
+    @Override
+    protected List getFieldOrder() {
+        List fieldOrder = new ArrayList(super.getFieldOrder());
+        fieldOrder.addAll(Arrays.asList("pw_gecos", "pw_dir", "pw_shell"));
+        return fieldOrder;
     }
 
 }

--- a/src/main/java/org/jvnet/libpam/impl/PAMLibrary.java
+++ b/src/main/java/org/jvnet/libpam/impl/PAMLibrary.java
@@ -30,6 +30,8 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Native;
 import com.sun.jna.Callback;
 import com.sun.jna.ptr.PointerByReference;
+import java.util.Arrays;
+import java.util.List;
 import static org.jvnet.libpam.impl.CLibrary.libc;
 
 /**
@@ -56,6 +58,10 @@ public interface PAMLibrary extends Library {
         public pam_message(Pointer src) {
             useMemory(src);
             read();
+        }
+
+        protected List getFieldOrder() {
+            return Arrays.asList("msg_style", "msg");
         }
     }
 
@@ -89,6 +95,10 @@ public interface PAMLibrary extends Library {
             this.resp = libc.strdup(msg);
         }
 
+        protected List getFieldOrder() {
+            return Arrays.asList("resp", "resp_retcode");
+        }
+
         public static final int SIZE = new pam_response().size();
     }
 
@@ -106,6 +116,10 @@ public interface PAMLibrary extends Library {
 
         public pam_conv(PamCallback conv) {
             this.conv = conv;
+        }
+
+        protected List getFieldOrder() {
+            return Arrays.asList("conv", "_");
         }
     }
 

--- a/src/main/java/org/jvnet/libpam/impl/SolarisPasswd.java
+++ b/src/main/java/org/jvnet/libpam/impl/SolarisPasswd.java
@@ -25,6 +25,10 @@
 
 package org.jvnet.libpam.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.jvnet.libpam.impl.CLibrary.passwd;
 
 /**
@@ -69,6 +73,14 @@ public class SolarisPasswd extends passwd {
     @Override
     public String getPwShell() {
         return pw_shell;
+    }
+
+    @Override
+    protected List getFieldOrder() {
+        List fieldOrder = new ArrayList(super.getFieldOrder());
+        fieldOrder.addAll(Arrays.asList("pw_age", "pw_comment", "pw_gecos",
+                "pw_dir", "pw_shell"));
+        return fieldOrder;
     }
 
 }


### PR DESCRIPTION
When running libpam4j 1.6 with JNA 2.5.0, you get AbstractMethodErrors, since
JNA 2.5.0 added a new abstract method "getFieldOrder" to Structure.  This is
especially problematic if you have multiple libraries in an application that
depend on JNA, and some require 2.5.0, and others don't support it yet.

Caused by: java.lang.AbstractMethodError: com.sun.jna.Structure.getFieldOrder()Ljava/util/List;
    at com.sun.jna.Structure.fieldOrder(Structure.java:831)
    at com.sun.jna.Structure.getFields(Structure.java:857)
    at com.sun.jna.Structure.deriveLayout(Structure.java:983)
    at com.sun.jna.Structure.calculateSize(Structure.java:908)
    at com.sun.jna.Structure.calculateSize(Structure.java:896)
    at com.sun.jna.Structure.allocateMemory(Structure.java:357)
    at com.sun.jna.Structure.<init>(Structure.java:191)
    at com.sun.jna.Structure.<init>(Structure.java:180)
    at com.sun.jna.Structure.<init>(Structure.java:167)
    at com.sun.jna.Structure.<init>(Structure.java:159)
    at org.jvnet.libpam.impl.PAMLibrary$pam_conv.<init>(PAMLibrary.java:107)
    at org.jvnet.libpam.PAM.<init>(PAM.java:73)

I tested this code against my local Mac OS X machine to make sure that it at least works there, but I don't have easy access to environments to perform further testing.
