### PR TITLE
Makes local user information optional.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <artifactId>libpam4j</artifactId>
   <packaging>jar</packaging>
-  <version>1.9-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <name>Java binding for libpam.so</name>
 
   <properties>

--- a/src/main/java/org/jvnet/libpam/AuthenticatedUser.java
+++ b/src/main/java/org/jvnet/libpam/AuthenticatedUser.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009, Sun Microsystems, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.libpam;
+
+/**
+ * Represents a user that has been successfully authenticated by PAM.
+ * Instances should be immutable.
+ */
+public class AuthenticatedUser {
+    private final String userName;
+
+    /*package*/ AuthenticatedUser(String userName) throws PAMException {
+        if (null == userName) {
+            throw new PAMException("username may not be null.");
+        }
+        this.userName = userName;
+    }
+
+    /**
+     * Gets the unix account name. Never null.
+     */
+    public String getUserName() {
+        return userName;
+    }
+}

--- a/src/main/java/org/jvnet/libpam/PAM.java
+++ b/src/main/java/org/jvnet/libpam/PAM.java
@@ -117,7 +117,7 @@ public class PAM {
      * @throws PAMException
      *      If the authentication fails.
      */
-    public UnixUser authenticate(String username, String password) throws PAMException {
+    public AuthenticatedUser authenticate(String username, String password) throws PAMException {
         this.password = password;
         try {
             check(libpam.pam_set_item(pht,PAM_USER,username),"pam_set_item failed");
@@ -128,10 +128,11 @@ public class PAM {
             PointerByReference r = new PointerByReference();
             check(libpam.pam_get_item(pht,PAM_USER,r),"pam_get_item failed");
             String userName = r.getValue().getString(0);
-            passwd pwd = libc.getpwnam(userName);
-            if(pwd==null)
-                throw new PAMException("Authentication succeeded but no user information is available");
-            return new UnixUser(userName,pwd);
+            if (UnixUser.exists(userName)) {
+              return new UnixUser(userName);
+            } else {
+              return new AuthenticatedUser(userName);
+            }
         } finally {
             this.password = null;
         }

--- a/src/main/java/org/jvnet/libpam/UnixUser.java
+++ b/src/main/java/org/jvnet/libpam/UnixUser.java
@@ -38,13 +38,13 @@ import java.util.Set;
  *
  * @author Kohsuke Kawaguchi
  */
-public class UnixUser {
-    private final String userName, gecos, dir, shell;
+public class UnixUser extends AuthenticatedUser {
+    private final String gecos, dir, shell;
     private final int uid,gid;
     private final Set<String> groups;
 
     /*package*/ UnixUser(String userName, passwd pwd) throws PAMException {
-        this.userName = userName;
+        super(userName);
         this.gecos = pwd.getPwGecos();
         this.dir = pwd.getPwDir();
         this.shell = pwd.getPwShell();
@@ -91,21 +91,14 @@ public class UnixUser {
      * Copy constructor for mocking. Not intended for regular use. Only for testing.
      * This signature may change in the future.
      */
-    protected UnixUser(String userName, String gecos, String dir, String shell, int uid, int gid, Set<String> groups) {
-        this.userName = userName;
+    protected UnixUser(String userName, String gecos, String dir, String shell, int uid, int gid, Set<String> groups) throws PAMException {
+        super(userName);
         this.gecos = gecos;
         this.dir = dir;
         this.shell = shell;
         this.uid = uid;
         this.gid = gid;
         this.groups = groups;
-    }
-
-    /**
-     * Gets the unix account name. Never null.
-     */
-    public String getUserName() {
-        return userName;
     }
 
     /**

--- a/src/test/java/org/jvnet/libpam/InteractiveTester.java
+++ b/src/test/java/org/jvnet/libpam/InteractiveTester.java
@@ -43,8 +43,10 @@ public class InteractiveTester extends TestCase {
     }
 
     public void testOne() throws Exception {
-        UnixUser u = new PAM("sshd").authenticate(System.getProperty("user.name"), System.getProperty("password"));
+        AuthenticatedUser user = new PAM("sshd").authenticate(System.getProperty("user.name"), System.getProperty("password"));
         if(!printOnce) {
+            assertTrue(user instanceof UnixUser);
+            UnixUser u = (UnixUser)user;
             System.out.println(u.getUID());
             System.out.println(u.getGroups());
             printOnce = true;
@@ -83,12 +85,22 @@ public class InteractiveTester extends TestCase {
     }
 
     public static void main(String[] args) throws Exception {
-        UnixUser u = new PAM("sshd").authenticate(args[0], args[1]);
-        System.out.println(u.getUID());
-        System.out.println(u.getGroups());
-        System.out.println(u.getGecos());
-        System.out.println(u.getDir());
-        System.out.println(u.getShell());
+        String service = "sshd";
+        if (3 == args.length) {
+          service = args[2];
+        }
+        AuthenticatedUser user = new PAM(service).authenticate(args[0], args[1]);
+        System.out.println("Username: " + user.getUserName());
+        if (user instanceof UnixUser) {
+          UnixUser u = (UnixUser)user;
+          System.out.println(u.getUID());
+          System.out.println(u.getGroups());
+          System.out.println(u.getGecos());
+          System.out.println(u.getDir());
+          System.out.println(u.getShell());
+        } else {
+          System.out.println("User is not local");
+        }
     }
 
     private boolean printOnce;


### PR DESCRIPTION
* Changes PAM.authenticate to return a generic AuthenticatedUser.
** Uses UnixUser.exists instead of manually checking libc.passwd, then returns either
   a UnixUser or a generic AuthenticatedUser.
** Non-backwards compatible because of the method signature change on PAM.authenticate.
* Changes UnixUser to be a subclass of the generic AuthenticatedUser.

Fixes #2